### PR TITLE
Skip components without contours

### DIFF
--- a/Glyph Nanny.roboFontExt/lib/glyphNanny.py
+++ b/Glyph Nanny.roboFontExt/lib/glyphNanny.py
@@ -651,6 +651,10 @@ def testComponentMetrics(glyph):
     # no components
     if len(components) == 0:
         return
+    boxes = [c.box for c in components]
+    # a component has no contours
+    if None in boxes:
+        return
     report = dict(leftMessage=None, rightMessage=None, left=None, right=None, width=glyph.width, box=glyph.box)
     problem = False
     if len(components) > 1:


### PR DESCRIPTION
Fix for the traceback below. It happens when `nbspace` glyph uses `space` glyph as component, for example.

``` python
Traceback (most recent call last):
  File "lib/eventTools/eventManager.pyc", line 116, in callObserver_withMethod_forEvent_withInfo
  File "glyphNanny.py", line 88, in drawReport
  File "lib/fontObjects/robofabWrapper.pyc", line 3188, in getRepresentation
  File "/Applications/RoboFont.app/Contents/Resources/lib/python2.7/defcon/objects/glyph.py", line 641, in getRepresentation
  File "glyphNanny.py", line 423, in GlyphNannyReportFactory
  File "glyphNanny.py", line 397, in getGlyphReport
  File "glyphNanny.py", line 674, in testComponentMetrics
TypeError: 'NoneType' object has no attribute '__getitem__'
```
