### PR TITLE
Fix swapped developer/developerURL values

### DIFF
--- a/Glyph Nanny.roboFontExt/info.plist
+++ b/Glyph Nanny.roboFontExt/info.plist
@@ -33,9 +33,9 @@
 		</dict>
 	</array>
 	<key>developer</key>
-	<string>http://tools.typesupply.com</string>
-	<key>developerURL</key>
 	<string>Type Supply LLC</string>
+	<key>developerURL</key>
+	<string>http://tools.typesupply.com</string>
 	<key>html</key>
 	<false/>
 	<key>launchAtStartUp</key>


### PR DESCRIPTION
Looks like these were just reversed when the extension was initially built. Mechanic now looks for the developer name in info.plist, and the URL was being displayed erroneously.